### PR TITLE
Set Vite base path for GitHub Pages deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import react from '@vitejs/plugin-react';
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
+      base: '/Bypass-Quest/',
       server: {
         port: 3000,
         host: '0.0.0.0',


### PR DESCRIPTION
## Summary
- set the Vite `base` option to `/Bypass-Quest/` so assets load correctly when hosted under the repository path

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcc697415083229bbf35f9e7112d4b