### PR TITLE
Add GitHub Pages redirect to repository path

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -12,6 +12,16 @@
         background-color: #111827; /* bg-gray-900 */
       }
     </style>
+    <script>
+      (function redirectToGitHubPagesRepo() {
+        if (typeof window === 'undefined') return;
+        const repoPath = '/Bypass-Quest/';
+        const hostname = window.location.hostname;
+        if (hostname.endsWith('.github.io') && !window.location.pathname.startsWith(repoPath)) {
+          window.location.replace(repoPath);
+        }
+      })();
+    </script>
 
   <script type="importmap">
 {

--- a/index.html
+++ b/index.html
@@ -12,6 +12,16 @@
         background-color: #111827; /* bg-gray-900 */
       }
     </style>
+    <script>
+      (function redirectToGitHubPagesRepo() {
+        if (typeof window === 'undefined') return;
+        const repoPath = '/Bypass-Quest/';
+        const hostname = window.location.hostname;
+        if (hostname.endsWith('.github.io') && !window.location.pathname.startsWith(repoPath)) {
+          window.location.replace(repoPath);
+        }
+      })();
+    </script>
   <script type="importmap">
 {
   "imports": {


### PR DESCRIPTION
## Summary
- add a small inline script that redirects GitHub Pages visitors to the `/Bypass-Quest/` sub-path when they accidentally land on the site root
- include the script in the built `docs/index.html` so the deployed bundle performs the same redirect

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dce8c7674883229f9dfbe1e35640df